### PR TITLE
Update some broken links

### DIFF
--- a/lab/Workshop Instructions/01_Set_up.md
+++ b/lab/Workshop Instructions/01_Set_up.md
@@ -30,7 +30,7 @@ In this workshop we will be working with Azure AI Foundry. First, deploy the nec
 
 ## Navigating Azure AI Foundry
 
-![Azure AI Foundry logged in homepage](./Images/ai-Foundry-login-homepage.png)
+![Azure AI Foundry logged in homepage](./Images/ai-Foundry-homepage.png)
 
 1. To begin, navigate to the left-hand sidebar where you will find the **Management** section. Under this section, select **All Resources.** This action will lead you to a centralized area where all available resources and tools are displayed, giving you an overview of your current hub connections.
 

--- a/lab/Workshop Instructions/01_Set_up.md
+++ b/lab/Workshop Instructions/01_Set_up.md
@@ -30,7 +30,7 @@ In this workshop we will be working with Azure AI Foundry. First, deploy the nec
 
 ## Navigating Azure AI Foundry
 
-![Azure AI Foundry logged in homepage](./Images/ai-Foundry-homepage.png)
+![Azure AI Foundry logged in homepage](./Images/ai-foundry-homepage.png)
 
 1. To begin, navigate to the left-hand sidebar where you will find the **Management** section. Under this section, select **All Resources.** This action will lead you to a centralized area where all available resources and tools are displayed, giving you an overview of your current hub connections.
 

--- a/lab/Workshop Instructions/assets/AITour24_WKR540_Template.json
+++ b/lab/Workshop Instructions/assets/AITour24_WKR540_Template.json
@@ -116,11 +116,11 @@
                 }
               },
               {
-                "name": "gpt-4o-realtime-preview",
+                "name": "gpt-4o-mini-realtime-preview",
                 "model": {
                   "format": "OpenAI",
-                  "name": "gpt-4o-realtime-preview",
-                  "version": "2024-10-01"
+                  "name": "gpt-4o-mini-realtime-preview",
+                  "version": "2024-12-17"
                 },
                 "sku": {
                   "name": "GlobalStandard",

--- a/translations/ja/README.md
+++ b/translations/ja/README.md
@@ -46,8 +46,8 @@ Azure OpenAI の GPT-4o マルチモーダルモデルを活用し、Azure AI Fo
 
 ワークショップのステップバイステップの手順は以下から参照できます：
 
-- [Skillable ワークショップ手順](https://github.com/microsoft/aitour-interact-with-llms/blob/main/lab/Skillable%20Workshop%20Instructions/00_Introduction.md)
-- [Azure に直接デプロイする場合のワークショップ手順](https://github.com/microsoft/aitour-interact-with-llms/blob/main/lab/Workshop%20Instructions/00_Introduction.md) - フィールドストップ向け
+- [Skillable ワークショップ手順](https://github.com/microsoft/aitour-interact-with-llms/blob/main/translations/ja/lab/Skillable%20Workshop%20Instructions/00_Introduction.md)
+- [Azure に直接デプロイする場合のワークショップ手順](https://github.com/microsoft/aitour-interact-with-llms/blob/main/translations/ja/lab/Workshop%20Instructions/00_Introduction.md) - フィールドストップ向け
 
 ## 追加リソースと継続学習
 

--- a/translations/ja/lab/Workshop Instructions/01_Set_up.md
+++ b/translations/ja/lab/Workshop Instructions/01_Set_up.md
@@ -29,7 +29,7 @@
 
 ## Azure AI Foundryのナビゲート
 
-![Azure AI Foundry ログイン後のホームページ](../../../../lab/Workshop Instructions/Images/ai-Foundry-homepage.png)
+![Azure AI Foundry ログイン後のホームページ](../../../../lab/Workshop Instructions/Images/ai-foundry-homepage.png)
 
 1. まず、左サイドバーの**Management**セクションに移動します。このセクションの下にある**All Resources**を選択します。この操作で、利用可能なすべてのリソースとツールが表示される集中管理エリアに移動し、現在のハブ接続の概要を確認できます。
 

--- a/translations/ja/lab/Workshop Instructions/01_Set_up.md
+++ b/translations/ja/lab/Workshop Instructions/01_Set_up.md
@@ -29,7 +29,7 @@
 
 ## Azure AI Foundryのナビゲート
 
-![Azure AI Foundry ログイン後のホームページ](../../../../lab/Workshop Instructions/Images/ai-Foundry-login-homepage.png)
+![Azure AI Foundry ログイン後のホームページ](../../../../lab/Workshop Instructions/Images/ai-Foundry-homepage.png)
 
 1. まず、左サイドバーの**Management**セクションに移動します。このセクションの下にある**All Resources**を選択します。この操作で、利用可能なすべてのリソースとツールが表示される集中管理エリアに移動し、現在のハブ接続の概要を確認できます。
 

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -46,8 +46,8 @@ Azure AI Foundry에서 Azure OpenAI의 GPT-4o 멀티모달 모델을 활용하�
 
 워크숍의 단계별 지침은 아래에서 확인할 수 있습니다:
 
-- [Skillable 워크숍 지침](https://github.com/microsoft/aitour-interact-with-llms/blob/main/lab/Skillable%20Workshop%20Instructions/00_Introduction.md)
-- [Azure에 직접 배포하는 경우의 워크숍 지침](https://github.com/microsoft/aitour-interact-with-llms/blob/main/lab/Workshop%20Instructions/00_Introduction.md) - 현장 학습용
+- [Skillable 워크숍 지침](./lab/Skillable Workshop Instructions/00_Introduction.md)
+- [Azure에 직접 배포하는 경우의 워크숍 지침](./lab/Workshop Instructions/00_Introduction.md) - 현장 학습용
 
 ## 추가 자료 및 지속적인 학습
 

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -46,8 +46,8 @@ Azure AI Foundry에서 Azure OpenAI의 GPT-4o 멀티모달 모델을 활용하�
 
 워크숍의 단계별 지침은 아래에서 확인할 수 있습니다:
 
-- [Skillable 워크숍 지침](./lab/Skillable Workshop Instructions/00_Introduction.md)
-- [Azure에 직접 배포하는 경우의 워크숍 지침](./lab/Workshop Instructions/00_Introduction.md) - 현장 학습용
+- [Skillable 워크숍 지침](https://github.com/microsoft/aitour-interact-with-llms/blob/main/translations/ko/lab/Skillable%20Workshop%20Instructions/00_Introduction.md)
+- [Azure에 직접 배포하는 경우의 워크숍 지침](https://github.com/microsoft/aitour-interact-with-llms/blob/main/translations/ko/lab/Workshop%20Instructions/00_Introduction.md) - 현장 학습용
 
 ## 추가 자료 및 지속적인 학습
 

--- a/translations/ko/lab/Workshop Instructions/01_Set_up.md
+++ b/translations/ko/lab/Workshop Instructions/01_Set_up.md
@@ -29,7 +29,7 @@
 
 ## Azure AI Foundry 탐색하기
 
-![Azure AI Foundry 로그인 후 홈 화면](../../../../lab/Workshop Instructions/Images/ai-Foundry-login-homepage.png)
+![Azure AI Foundry 로그인 후 홈 화면](../../../../lab/Workshop Instructions/Images/ai-Foundry-homepage.png)
 
 1. 먼저, 왼쪽 사이드바에서 **Management** 섹션을 찾으세요. 이 섹션 아래에서 **All Resources**를 선택하세요. 이 작업을 통해 사용 가능한 모든 리소스와 도구가 표시되는 중앙화된 영역으로 이동하여 현재 허브 연결 상태를 한눈에 볼 수 있습니다.
 

--- a/translations/ko/lab/Workshop Instructions/01_Set_up.md
+++ b/translations/ko/lab/Workshop Instructions/01_Set_up.md
@@ -29,7 +29,7 @@
 
 ## Azure AI Foundry 탐색하기
 
-![Azure AI Foundry 로그인 후 홈 화면](../../../../lab/Workshop Instructions/Images/ai-Foundry-homepage.png)
+![Azure AI Foundry 로그인 후 홈 화면](../../../../lab/Workshop Instructions/Images/ai-foundry-homepage.png)
 
 1. 먼저, 왼쪽 사이드바에서 **Management** 섹션을 찾으세요. 이 섹션 아래에서 **All Resources**를 선택하세요. 이 작업을 통해 사용 가능한 모든 리소스와 도구가 표시되는 중앙화된 영역으로 이동하여 현재 허브 연결 상태를 한눈에 볼 수 있습니다.
 

--- a/translations/tw/README.md
+++ b/translations/tw/README.md
@@ -46,8 +46,8 @@
 
 詳細的工作坊步驟指導如下：
 
-- [Skillable 工作坊指導](https://github.com/microsoft/aitour-interact-with-llms/blob/main/lab/Skillable%20Workshop%20Instructions/00_Introduction.md)
-- [直接在 Azure 上部署的工作坊指導](https://github.com/microsoft/aitour-interact-with-llms/blob/main/lab/Workshop%20Instructions/00_Introduction.md) - 適用於現場站點
+- [Skillable 工作坊指導](https://github.com/microsoft/aitour-interact-with-llms/blob/main/translations/tw/lab/Skillable%20Workshop%20Instructions/00_Introduction.md)
+- [直接在 Azure 上部署的工作坊指導](https://github.com/microsoft/aitour-interact-with-llms/blob/main/translations/tw/lab/Workshop%20Instructions/00_Introduction.md) - 適用於現場站點
 
 ## 附加資源與持續學習
 

--- a/translations/tw/lab/Workshop Instructions/01_Set_up.md
+++ b/translations/tw/lab/Workshop Instructions/01_Set_up.md
@@ -30,7 +30,7 @@
 
 ## 瀏覽 Azure AI Foundry
 
-![Azure AI Foundry 登入首頁](../../../../lab/Workshop Instructions/Images/ai-Foundry-login-homepage.png)
+![Azure AI Foundry 登入首頁](../../../../lab/Workshop Instructions/Images/ai-Foundry-homepage.png)
 
 1. 首先，導航到左側邊欄中的 **Management** 區域。在此區域中選擇 **All Resources**。此操作將引導您進入一個集中式區域，顯示所有可用的資源和工具，讓您能夠概覽目前的中心連接。
 

--- a/translations/tw/lab/Workshop Instructions/01_Set_up.md
+++ b/translations/tw/lab/Workshop Instructions/01_Set_up.md
@@ -30,7 +30,7 @@
 
 ## 瀏覽 Azure AI Foundry
 
-![Azure AI Foundry 登入首頁](../../../../lab/Workshop Instructions/Images/ai-Foundry-homepage.png)
+![Azure AI Foundry 登入首頁](../../../../lab/Workshop Instructions/Images/ai-foundry-homepage.png)
 
 1. 首先，導航到左側邊欄中的 **Management** 區域。在此區域中選擇 **All Resources**。此操作將引導您進入一個集中式區域，顯示所有可用的資源和工具，讓您能夠概覽目前的中心連接。
 

--- a/translations/zh/README.md
+++ b/translations/zh/README.md
@@ -46,8 +46,8 @@
 
 以下是分步的工作坊指南：
 
-- [Skillable 工作坊指南](https://github.com/microsoft/aitour-interact-with-llms/blob/main/lab/Skillable%20Workshop%20Instructions/00_Introduction.md)
-- [直接在 Azure 上部署的工作坊指南](https://github.com/microsoft/aitour-interact-with-llms/blob/main/lab/Workshop%20Instructions/00_Introduction.md) - 适用于现场活动
+- [Skillable 工作坊指南](https://github.com/microsoft/aitour-interact-with-llms/blob/main/translations/zh/lab/Skillable%20Workshop%20Instructions/00_Introduction.md)
+- [直接在 Azure 上部署的工作坊指南](https://github.com/microsoft/aitour-interact-with-llms/blob/main/translations/zh/lab/Workshop%20Instructions/00_Introduction.md) - 适用于现场活动
 
 ## 额外资源和持续学习
 

--- a/translations/zh/lab/Workshop Instructions/01_Set_up.md
+++ b/translations/zh/lab/Workshop Instructions/01_Set_up.md
@@ -29,7 +29,7 @@
 
 ## 浏览 Azure AI Foundry
 
-![Azure AI Foundry 登录首页](../../../../lab/Workshop Instructions/Images/ai-Foundry-homepage.png)
+![Azure AI Foundry 登录首页](../../../../lab/Workshop Instructions/Images/ai-foundry-homepage.png)
 
 1. 首先，导航到左侧边栏，找到 **Management** 部分。在该部分下，选择 **All Resources**。此操作将带您进入一个集中区域，显示所有可用资源和工具，提供当前中心连接的概览。
 

--- a/translations/zh/lab/Workshop Instructions/01_Set_up.md
+++ b/translations/zh/lab/Workshop Instructions/01_Set_up.md
@@ -29,7 +29,7 @@
 
 ## 浏览 Azure AI Foundry
 
-![Azure AI Foundry 登录首页](../../../../lab/Workshop Instructions/Images/ai-Foundry-login-homepage.png)
+![Azure AI Foundry 登录首页](../../../../lab/Workshop Instructions/Images/ai-Foundry-homepage.png)
 
 1. 首先，导航到左侧边栏，找到 **Management** 部分。在该部分下，选择 **All Resources**。此操作将带您进入一个集中区域，显示所有可用资源和工具，提供当前中心连接的概览。
 


### PR DESCRIPTION
Hi, team.
I noticed a few broken and outdated links in the documentation.
Here's what I've updated in this PR :
- Fixed links in translated README files to point to the translated workshop instructions.
- Updated the login homage image links in the setup documents.
- Updated the outdated OpenAI model name in the Azure deploy template.

Thanks.